### PR TITLE
Fix on the fly filtering, add in appropriate no-op members

### DIFF
--- a/protodroid-no-op/src/main/java/id/lukasdylan/grpc/protodroid/Protodroid.kt
+++ b/protodroid-no-op/src/main/java/id/lukasdylan/grpc/protodroid/Protodroid.kt
@@ -7,6 +7,7 @@ class Protodroid private constructor(context: Context) {
 
     var loggingEnabled: Boolean = false
     var notifySuccessful: Boolean = true
+    var defaultUniqueErrors: Boolean = false
 
     suspend fun saveNewData(dataState: ProtodroidDataState) {}
 

--- a/protodroid-no-op/src/main/java/id/lukasdylan/grpc/protodroid/ProtodroidInterceptor.kt
+++ b/protodroid-no-op/src/main/java/id/lukasdylan/grpc/protodroid/ProtodroidInterceptor.kt
@@ -29,6 +29,8 @@ open class ProtodroidInterceptor internal constructor(
 
         fun loggingEnabled(enabled: Boolean) = apply {}
 
+        fun defaultUniqueErrors(enabled: Boolean) = apply {}
+
         fun build(): ProtodroidInterceptor {
             return ProtodroidInterceptor(this)
         }


### PR DESCRIPTION
- Add the missing no-op members
- Add in call to fetch all data so when a user is toggling from "Errors only" to "Show successful", the successful items appear instantly